### PR TITLE
Change default engine from Kohler ch750 to Audi i5

### DIFF
--- a/assets/main.mr
+++ b/assets/main.mr
@@ -1,8 +1,8 @@
 import "engine_sim.mr"
 import "themes/default.mr"
-import "engines/kohler/kohler_ch750.mr"
+import "engines/audi/i5.mr"
 
 use_default_theme()
 set_engine(
-    kohler_ch750()
+    audi_i5_2_2L()
 )


### PR DESCRIPTION
This is in response to the number of people who are confused by the default engine not going into gear without stalling.